### PR TITLE
对VVQuest和label_image添加了对OpenAI格式的支持

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,5 +1,10 @@
 api:
-  silicon_api_key:
+  embedding_models:
+    base_url: https://api.siliconflow.com/v1
+    api_key: 
+  vlm_models:
+    base_url: https://api.siliconflow.com/v1
+    api_key: 
 misc:
   adapt_for_old_version: true
 models:

--- a/config/settings.py
+++ b/config/settings.py
@@ -31,8 +31,13 @@ class PathsConfig(BaseConfig):
     api_embeddings_cache_file: str
     label_images_cache_file: str
 
+class OpenaiConfig(BaseConfig):
+    base_url: str
+    api_key: Optional[str] = None
+
 class ApiConfig(BaseConfig):
-    silicon_api_key: Optional[str] = None
+    embedding_models: OpenaiConfig
+    vlm_models: OpenaiConfig
 
 class MiscConfig(BaseConfig):
     adapt_for_old_version: bool

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ confz
 opencv-python
 pyyaml
 pillow
+openai

--- a/services/label_memes.py
+++ b/services/label_memes.py
@@ -5,6 +5,8 @@ from config.settings import config
 import cv2
 from PIL import Image, ImageEnhance
 import io
+import openai
+from openai import OpenAI
 
 PROMOTE = """你是一位表情包分类专家。请分析这个表情包，要求：
 
@@ -14,8 +16,8 @@ PROMOTE = """你是一位表情包分类专家。请分析这个表情包，要�
 
 class LabelMemes():
     def __init__(self):
-        self.api_key = config.api.silicon_api_key
-        self.endpoint = "https://api.siliconflow.com/v1/embeddings"
+        self.api_key = config.api.vlm_models.api_key
+        self.base_url = config.api.vlm_models.base_url
         self.cache = {}
         self.use_cache = False
         self._load_cache()
@@ -161,12 +163,7 @@ class LabelMemes():
             "stop": ["null"],
             "temperature": 0.5,
             "top_p": 0.5,
-            "top_k": 50,
             "frequency_penalty": 0.0,
-        }
-        headers = {
-            "Authorization": f"Bearer {config.api.silicon_api_key}",
-            "Content-Type": "application/json"
         }
 
 
@@ -195,9 +192,9 @@ class LabelMemes():
         '''
 
         try:
-            response = requests.request("POST", url, json=payload, headers=headers)
-            response.raise_for_status()  # 抛出详细的HTTP错误
-            description = response.json()['choices'][0]['message']['content']
+            client = OpenAI(api_key=self.api_key, base_url=self.base_url)
+            response = client.chat.completions.create(**payload)
+            description = response.choices[0].message.content
             
             # 缓存结果
             self.cache[model_name][get_file_hash(image_path)] = {
@@ -207,13 +204,16 @@ class LabelMemes():
             self._save_cache()
             
             return self._analyze_result_text(description)
-            
-        except requests.exceptions.RequestException as e:
-            if hasattr(e.response, 'status_code') and e.response.status_code == 400:
-                # 尝试打印详细的错误信息
-                error_msg = e.response.json() if e.response.text else "未知错误"
-                print(f"API请求参数错误: {str(error_msg).replace(img_str, 'IMGDATA')}")
+        
+        except openai.OpenAIError as e:
             raise RuntimeError(f"API请求失败: {str(e)}\n请求参数: {str(payload).replace(img_str, 'IMGDATA')}")
+            
+        # except requests.exceptions.RequestException as e:
+        #     if hasattr(e.response, 'status_code') and e.response.status_code == 400:
+        #         # 尝试打印详细的错误信息
+        #         error_msg = e.response.json() if e.response.text else "未知错误"
+        #         print(f"API请求参数错误: {str(error_msg).replace(img_str, 'IMGDATA')}")
+        #     raise RuntimeError(f"API请求失败: {str(e)}\n请求参数: {str(payload).replace(img_str, 'IMGDATA')}")
 
 if __name__ == "__main__":
     lm = LabelMemes()


### PR DESCRIPTION
如题，使用openai库替代了request库的实现，并且添加了灵活的base_url设置，可以在config文件中修改embedding模型或者vlm模型的提供者，并且设置硅基流动为默认提供商。

此外，在VVQuest页面添加了修改base url的选项，用户可以在界面中直接更改base url

<img width="562" alt="image" src="https://github.com/user-attachments/assets/127ca5c8-54f1-48ab-9120-6137d4899e3c" />
